### PR TITLE
Add beat detection

### DIFF
--- a/js/app/background.js
+++ b/js/app/background.js
@@ -19,18 +19,18 @@ function(config, Visualizer){
      */
     Background.prototype.start = function(game) {
         this.game = game;
-
-        this.music = this.game.add.audio('background1', 1, true);
-        this.music.play();
-
-        this.visualizer = new Visualizer(game, this.music);
+        if (this.game.sound.usingWebAudio) {
+            this.visualizer = new Visualizer(game);
+        }
     }
 
     /**
      * Update the background
      */
     Background.prototype.update = function(){
-        this.visualizer.draw();
+        if (this.visualizer) {
+            this.visualizer.draw();
+        }
     }
 
     return new Background();

--- a/js/app/config.js
+++ b/js/app/config.js
@@ -18,12 +18,18 @@ define(function(){
      * @property {number}  config.grid.numCells     - Number of cells per row/column
      * @property {number}  config.grid.linesVisible - Hide/show grid lines
      *
-     * @property {object}  config.color             - Color options
+     * @property {object}  config.color              - Color options
      * @property {number}  config.color.unbreakable  - Color of the central unbreakable blocks
      * @property {number}  config.color.available    - List of colors used for levels in ascending order
      *
      * @property {object}  config.generator              - Generator settings
      * @property {number}  config.generator.defaultWait  - Time in seconds to wait before dropping a quad
+     *
+     * @property {object}  config.sound                   - Sound settings
+     * @property {object}  config.sound.beat              - Beat detection settings
+     * @property {number}  config.sound.beat.delay        - Minimum frames between beats
+     * @property {number}  config.sound.beat.decayRate    - Decay rate of beat threshold
+     * @property {number}  config.sound.beat.minThreshold - Minimum volume of beat
      */
     var config = {
         game : {
@@ -43,6 +49,13 @@ define(function(){
         },
         generator : {
             defaultWait : 4
+        },
+        sound : {
+            beat : {
+                delay : 45,
+                decayRate : 0.95,
+                minThreshold : 60
+            }
         }
     };
 

--- a/js/app/grid.js
+++ b/js/app/grid.js
@@ -2,7 +2,8 @@
  * Exposes a singleton Grid which defines the main gameplay field
  * @module app/grid
  */
-define(["app/config", "Phaser"], function(config, Phaser){
+define(["app/config", "Phaser", "app/music"],
+function(config, Phaser, music){
     "use strict"
 
     /**
@@ -41,6 +42,22 @@ define(["app/config", "Phaser"], function(config, Phaser){
      * Show the grid of 'cells' that the blocks can be moved around on
      */
     Grid.prototype.display = function(game) {
+        this.outerGraphic = game.add.graphics(this.offsets.x, this.offsets.y);
+        this.outerGraphic.lineStyle(1, 0xFFFFFF, 0.6);
+        this.outerGraphic.drawRect(0, 0, config.grid.size, config.grid.size);
+
+        music.onBeat.push(function(){
+            var tween = game.add.tween(this.outerGraphic.scale);
+            tween.to({x: 1.1, y:1.1}, 75).to({x:1, y:1}, 100).start();
+
+            var locationTween = game.add.tween(this.outerGraphic);
+            locationTween.to({
+                x: this.offsets.x - config.grid.size*0.05,
+                y: this.offsets.y - config.grid.size*0.05
+            }, 75).to({x: this.offsets.x, y: this.offsets.y}, 100).start();
+        }.bind(this));
+
+
         this.graphics = game.add.graphics(this.offsets.x, this.offsets.y);
         this.graphics.lineStyle(1, 0xFFFFFF, 0.2);
         this.graphics.beginFill(0x666666, 0.1);

--- a/js/app/music.js
+++ b/js/app/music.js
@@ -1,0 +1,113 @@
+/**
+ * A module which gathers information about the currently playing music
+ * @module app/music
+ */
+define(["app/config"], function(config){
+    "use strict"
+
+    /**
+     * A class which plays music and gathers information about it
+     * @alias module:app/music
+     *
+     */
+    var MusicManager = function() {}
+
+    /**
+     * Start the music manager, playing 'music'
+     *
+     * @param {string} [music] - Key of initial song to play
+     */
+    MusicManager.prototype.start = function(game, music) {
+        this.game = game;
+
+        /**
+         * WebAudio node which analysis the current music
+         */
+        this.analyser = this.game.sound.context.createAnalyser();
+
+        this.analyser.minDecibels = -140;
+        this.analyser.maxDecibels = 0;
+        this.analyser.fftSize = 2048;
+        this.analyser.smoothingTimeConstant = 0.8;
+
+        this.freqs = new Uint8Array(this.analyser.frequencyBinCount);
+        this.times = new Uint8Array(this.analyser.frequencyBinCount);
+
+        this.beatThreshold = 0;
+        this.beatCounter = 0;
+
+        /**
+         * Callbacks to be executed on a beat
+         * @type {function[]}
+         */
+        this.onBeat = [];
+
+        if (music)
+            this.play(music);
+    }
+
+    /**
+     * Play music loaded with the given id
+     *
+     * @param {string} music - The key used to load the sound asset in 'preload'
+     */
+    MusicManager.prototype.play = function(music) {
+        var oldMusic = this.music;
+
+        if (oldMusic) {
+            oldMusic.externalNode = null;
+            this.analyser.disconnect();
+            oldMusic.destroy();
+        }
+
+        this.music = this.game.add.audio(music, 1, true);
+
+        this.music.externalNode = this.analyser;
+        this.analyser.connect(this.music.masterGainNode);
+        this.music.play();
+
+        return this;
+    }
+
+    /**
+     * Update the analyzer (and do beat detection)
+     */
+    MusicManager.prototype.update = function() {
+        this.detectBeat();
+    }
+
+    MusicManager.prototype.getAverageFreq = function() {
+        var avg = 0;
+	for(var i = 0; i < this.freqs.length; i++) {
+	    avg += this.freqs[i];
+	}
+        return avg /= this.freqs.length;
+    }
+
+    /**
+     * Test if there is currently a beat being played
+     */
+    MusicManager.prototype.detectBeat = function(){
+        var avg = this.getAverageFreq();
+	if (avg > this.beatThreshold && avg > config.sound.beat.minThreshold){
+	    this.beatThreshold = avg*1.1;
+	    this.beatCounter = 0;
+
+            this.onBeat.map(function(callback){
+                callback();
+            });
+	} else {
+	    if (this.beatCounter <= config.sound.beat.delay){
+		this.beatCounter++;
+	    }else{
+		this.beatThreshold *= config.sound.beat.decayRate;
+                this.beatThreshold = Math.max(this.beatThreshold,
+                                              config.sound.beat.minThreshold);
+	    }
+	}
+        return this;
+    }
+
+    var music = new MusicManager();
+    return music;
+});

--- a/js/app/state/create.js
+++ b/js/app/state/create.js
@@ -3,8 +3,8 @@
  * phase of Phaser js startup
  * @module app/state/create
  */
-define(["app/grid", "app/generator", "app/background"],
-function(grid, generator, background){
+define(["app/grid", "app/generator", "app/background", "app/music"],
+function(grid, generator, background, music){
     "use strict"
 
     /**
@@ -14,10 +14,10 @@ function(grid, generator, background){
      * @param {Phaser.Game} game - The current game object
      */
     var create = function(game){
+        music.start(game, 'background1');
         background.start(game);
         grid.display(game);
         generator.start(game);
-
     };
     return create;
 });

--- a/js/app/state/update.js
+++ b/js/app/state/update.js
@@ -2,8 +2,8 @@
  * A module returning a function which will be executed during each frame
  * @module app/state/update
  */
-define(["app/controls", "app/generator", "app/background"],
-function(controls, generator, background){
+define(["app/controls", "app/generator", "app/background", "app/music"],
+function(controls, generator, background, music){
     "use strict"
 
     /**
@@ -13,6 +13,7 @@ function(controls, generator, background){
      * @param {Phaser.Game} game - The current game object
      */
     var update = function(game) {
+        music.update();
         controls.update(game);
         generator.update();
         background.update();

--- a/js/app/visualizer.js
+++ b/js/app/visualizer.js
@@ -18,7 +18,7 @@
  * A module which displays a visualization of background music
  * @module app/visualizer
  */
-define(["app/config"], function(config){
+define(["app/config", "app/music"], function(config, music){
     "use strict"
 
     /**
@@ -27,41 +27,15 @@ define(["app/config"], function(config){
      * @alias module:app/visualizer
      *
      * @param {Phaser.Game} game - A reference to the current game
-     * @param {Phaser.Sound} [music] - Initial background music
      */
-    function Visualizer(game, music) {
+    var Visualizer = function(game) {
         this.game = game;
-        this.bmd = this.game.make.bitmapData(config.game.width, config.game.height/2);
+        this.bmd = this.game.make.bitmapData(config.game.width,
+                                             config.game.height/2);
         this.bmd.addToWorld(0, config.game.height/2);
-
-        this.analyser = this.game.sound.context.createAnalyser();
-
-        this.analyser.minDecibels = -140;
-        this.analyser.maxDecibels = 0;
-        this.analyser.fftSize = 2048;
-
-        this.freqs = new Uint8Array(this.analyser.frequencyBinCount);
-        this.times = new Uint8Array(this.analyser.frequencyBinCount);
 
         this.canvas = this.bmd.canvas;
         this.drawContext = this.bmd.context;
-        this.analyser.smoothingTimeConstant = 0.8;
-
-        if (music) {
-            this.setMusic(music);
-        }
-    }
-
-    /**
-     * Set the visualizer to display the given sound
-     *
-     * @param {Phaser.Sound} music - New sound to display
-     * @note This does not start playing the music
-     */
-    Visualizer.prototype.setMusic = function(music) {
-        this.music = music;
-        this.music.externalNode = this.analyser;
-        this.analyser.connect(this.music.masterGainNode);
     }
 
     /**
@@ -69,34 +43,30 @@ define(["app/config"], function(config){
      */
     Visualizer.prototype.draw = function() {
         // Get the frequency data from the currently playing music
-        this.analyser.getByteFrequencyData(this.freqs);
-        this.analyser.getByteTimeDomainData(this.times);
+        music.analyser.getByteFrequencyData(music.freqs);
+        music.analyser.getByteTimeDomainData(music.times);
         this.bmd.cls();
         // Draw the frequency domain chart.
-        for (var i = 0; i < this.analyser.frequencyBinCount; ++i) {
-            var value = this.freqs[i];
+        for (var i = 0; i < music.analyser.frequencyBinCount; ++i) {
+            var value = music.freqs[i];
             var percent = value / 256;
             var height = this.canvas.height * percent;
             var offset = this.canvas.height - height;
-            var barWidth = this.canvas.width/this.analyser.frequencyBinCount;
+            var barWidth = this.canvas.width/music.analyser.frequencyBinCount;
 
             this.bmd.rect(i * barWidth, offset, barWidth, height, "rgba(0, 0, 0, 0.5)");
         }
 
-        for (var i = 0; i < this.analyser.frequencyBinCount; i++) {
-            var value = this.times[i];
+        for (var i = 0; i < music.analyser.frequencyBinCount; i++) {
+            var value = music.times[i];
             var percent = value / 256 /4;
             var height = this.canvas.height * percent;
             var offset = this.canvas.height - height - this.canvas.height/4;
-            var barWidth = this.canvas.width/this.analyser.frequencyBinCount;
+            var barWidth = this.canvas.width/music.analyser.frequencyBinCount;
             this.bmd.rect(i * barWidth, offset, 1, 2, "rgba(255, 255, 255, 0.8)");
         }
-    }
 
-    Visualizer.prototype.getFrequencyValue = function(freq) {
-        var nyquist = this.game.sound.context.sampleRate/2;
-        var index = Math.round(freq/nyquist * this.freqs.length);
-        return this.freqs[index];
+        return this;
     }
 
     return Visualizer;


### PR DESCRIPTION
I'm going to start opening pull requests for the features I add so you guys can review them before I merge them into master. I'll probably leave them open for a day and merge if no one has any problems.

This change adds support for beat detection through a 'music' module. This module also provides the frequency and time information required by the background visualizations. Any music changes (for changing levels, for example), should be done by calling `music.play(key)`, where `key` is the key the asset was loaded with in `preload`.

As an example, this change causes a border around the grid to pulse with the beat. The scoreboard should probably take advantage of this where appropriate.