### PR TITLE
Show lines indicating drop limits

### DIFF
--- a/js/app/controls.js
+++ b/js/app/controls.js
@@ -9,7 +9,9 @@ function(config, generator, Phaser, grid){
     var controls = {
         rotating : false,
         shifting : false,
-        postMove : function() {},
+        postMove : function() {
+            generator.showLimits();
+        },
         keys : [],
 
         /**

--- a/js/app/generator.js
+++ b/js/app/generator.js
@@ -43,6 +43,7 @@ function(config, Phaser, Quad, grid){
         this.dropTimer = null;
 
         this.timerGraphic = null;
+        this.limitGraphic = null;
 
         this.directions = [
             "top",
@@ -80,6 +81,7 @@ function(config, Phaser, Quad, grid){
         this.dropTimer.loop(speed * Phaser.Timer.SECOND,
             this.drop.bind(this));
         this.timerGraphic = this.game.add.graphics();
+        this.limitGraphic = this.game.add.graphics();
         var self=this;
 
         // Show the next 4 moves
@@ -117,6 +119,7 @@ function(config, Phaser, Quad, grid){
         this.showFutureQuads();
 
         this.dropTimer.start();
+        generator.showLimits();
         return this;
     }
 
@@ -181,6 +184,63 @@ function(config, Phaser, Quad, grid){
         this.waitingQuads.map(function(quad){
             quad.highlightPath();
         })
+        return this;
+    }
+
+    /**
+     * Show lines indicating unreachable blocks in the current configuration
+     */
+    Generator.prototype.showLimits = function() {
+        if (!this.waitingQuads.length)
+            return this;
+
+        var direction = this.waitingQuads[0].direction;
+        this.limitGraphic.clear();
+        this.limitGraphic.beginFill(0x222222, 0.2);
+        switch(direction.toLowerCase()) {
+        case "top":
+        case "bottom":
+            var leftLimit = config.grid.numCells/2 - grid.getLimit("right")-1;
+            var rightLimit = config.grid.numCells/2 + grid.getLimit("left")+1;
+
+            // draw left limit
+            if (leftLimit > grid.getLimit("left")) {
+                var top = grid.coordToPoint({x: leftLimit, y: 0});
+                this.limitGraphic.drawRect(top.x, top.y,
+                                           2, config.grid.size);
+            }
+
+            // draw right limit
+            if (rightLimit < config.grid.numCells - grid.getLimit("right")) {
+                top = grid.coordToPoint({x: rightLimit, y: 0});
+                this.limitGraphic.drawRect(top.x, top.y,
+                                           2, config.grid.size);
+            }
+            break;
+        case "left":
+        case "right":
+            var topLimit = config.grid.numCells/2 - grid.getLimit("bottom")-1;
+            var bottomLimit = config.grid.numCells/2 + grid.getLimit("top")+1;
+
+            // draw top limit
+            if (topLimit > grid.getLimit("top")) {
+                var top = grid.coordToPoint({x: 0, y: topLimit});
+                this.limitGraphic.drawRect(top.x, top.y,
+                                           config.grid.size, 2);
+            }
+
+            // draw bottom limit
+            if (bottomLimit < config.grid.numCells - grid.getLimit("bottom")) {
+                top = grid.coordToPoint({x: 0, y: bottomLimit});
+                this.limitGraphic.drawRect(top.x, top.y,
+                                           config.grid.size, 2);
+            }
+            break;
+        default:
+            this.limitGraphic.endFill();
+            throw("Invalid argument to 'showLimits': " + direction);
+        }
+        this.limitGraphic.endFill();
         return this;
     }
 

--- a/js/app/grid.js
+++ b/js/app/grid.js
@@ -149,6 +149,56 @@ function(config, Phaser, music){
     }
 
     /**
+     * Determine the number of cells between the wall in 'direction' and the
+     * furthest block in that direction.
+     *
+     * @param {string} direction - One of 'top', 'right', 'bottom', 'left'
+     */
+    Grid.prototype.getLimit = function(direction) {
+        switch(direction.toLowerCase()) {
+        case "top":
+            for (var i=0; i < config.grid.numCells; ++i) {
+                if (this.contents[i].some(function(cell) {
+                    return typeof(cell) !== "undefined"
+                })) {
+                    return i;
+                }
+            }
+            break;
+        case "right":
+            for (var i=config.grid.numCells-1; i >= 0; --i) {
+                for (var j=0; j < config.grid.numCells; ++j) {
+                    if (this.contents[j][i]) {
+                        return (config.grid.numCells-1)-i;
+                    }
+                }
+            }
+            break;
+        case "bottom":
+            for (var i=config.grid.numCells-1; i >= 0; --i) {
+                if (this.contents[i].some(function(cell) {
+                    return typeof(cell) !== "undefined"
+                })) {
+                    return (config.grid.numCells-1)-i;
+                }
+            }
+            break;
+        case "left":
+            for (var i=0; i < config.grid.numCells; ++i) {
+                for (var j=0; j < config.grid.numCells; ++j) {
+                    if (this.contents[j][i]) {
+                        return i;
+                    }
+                }
+            }
+            break;
+        default:
+            throw("Invalid argument to 'getLimit': " + direction);
+        }
+        return null;
+    }
+
+    /**
      * Get the first free position on the grid when comming from `direction` at
      * `position`. This is the coordinate that a block should take if it is being
      * 'dropped'.


### PR DESCRIPTION
Implements #10. I think this information should definitely be available to the user, but I'm not sure if this is the best form. Currently, faint lines are shown if there are blocks outside of area where the waiting quad could be dropped from the current direction.

As an alternative, the limits from all directions could be shown, regardless of the current direction. 