### PR TITLE
Add effects for start of first level

### DIFF
--- a/js/app/background.js
+++ b/js/app/background.js
@@ -12,7 +12,7 @@ function(config, Phaser, Visualizer, music){
         var y = (Math.random() * config.game.height);// - config.game.height/2;
         this.graphics = this.game.add.graphics(x, y);
         this.game.world.sendToBack(this.graphics);
-        this.graphics.alpha = 0.5;
+        this.graphics.alpha = 0;
         this.graphics.scale = {x: 0.5, y: 0.5};
 
         this.graphics.lineStyle(2, 0x222222, 0.4);
@@ -21,6 +21,9 @@ function(config, Phaser, Visualizer, music){
                                config.game.width,
                                config.game.height);
         this.graphics.endFill();
+
+        // Fade in the blocks
+        this.game.add.tween(this.graphics).to({alpha : 0.5}, 2000).start();
 
         music.onBeat.push(function(){
             this.pulse();

--- a/js/app/generator.js
+++ b/js/app/generator.js
@@ -253,10 +253,16 @@ function(config, Phaser, Quad, grid){
      * Set the current level.
      */
     Generator.prototype.setLevel = function(level) {
-        this.level = level;
-        this.updateCurrentQuadLevel(this.level);
-        var speed = config.generator.speeds[this.level];
-        this.dropTimer.loop(speed * Phaser.Timer.SECOND, this.drop.bind(this));
+        if (this.level != level) {
+            this.level = level;
+            this.updateCurrentQuadLevel(this.level);
+            var speed = config.generator.speeds[this.level];
+            this.dropTimer.loop(speed * Phaser.Timer.SECOND, this.drop.bind(this));
+        }
+        this.dropTimer.stop(false);
+
+        // Pause for the level transition effects
+        this.dropTimer.start(3000);
     }
 
     /**

--- a/js/app/music.js
+++ b/js/app/music.js
@@ -29,6 +29,7 @@ define(["app/config"], function(config){
          * WebAudio node which is used to crossfade
          */
         this.gain = this.game.sound.context.createGain();
+        this.gain.gain.value = 0;
 
         this.analyser.minDecibels = -140;
         this.analyser.maxDecibels = 0;
@@ -69,7 +70,6 @@ define(["app/config"], function(config){
      */
     MusicManager.prototype.play = function(music) {
         var oldMusic = this.music;
-        this.fade("out", this.crossfadeDuration/2);
 
         var playNew = function(){
             if (oldMusic) {
@@ -83,11 +83,15 @@ define(["app/config"], function(config){
             this.analyser.connect(this.music.masterGainNode);
             this.music.play();
 
-            this.fade("in", this.crossfadeDuration/2);
+            if (oldMusic)
+                this.fade("in", this.crossfadeDuration/2);
+            else
+                this.fade("in", this.crossfadeDuration*5);
         }.bind(this);
 
         // Only crossfade if there is an already playing song
         if (this.music){
+            this.fade("out", this.crossfadeDuration/2);
             setTimeout(playNew, this.crossfadeDuration);
         } else {
             playNew();

--- a/js/app/score.js
+++ b/js/app/score.js
@@ -31,6 +31,7 @@ function(config, music, background){
         this.board = game.add.text(game.world.centerX + 150, 27, text, style);
         this.grid = grid;
         this.generator = generator;
+        this.setLevel(0);
     }
 
     /**

--- a/js/app/state/create.js
+++ b/js/app/state/create.js
@@ -14,7 +14,7 @@ function(grid, generator, background, music, score){
      * @param {Phaser.Game} game - The current game object
      */
     var create = function(game){
-        music.start(game, 'background1');
+        music.start(game);
         background.start(game);
         grid.display(game);
         generator.start(game);


### PR DESCRIPTION
Shows the level transition effect to the first level, and fade in the background music and visualizations. This PR also adds a 3 second pause on the drop timer between levels (and at the start fixing #20).